### PR TITLE
sync occt commit id: 49259460

### DIFF
--- a/src/patches/issue_0032061.patch
+++ b/src/patches/issue_0032061.patch
@@ -1,0 +1,167 @@
+diff --git a/src/RWGltf/RWGltf_CafWriter.cxx b/src/RWGltf/RWGltf_CafWriter.cxx
+index 0b4f2a0f5c..6c8dca20c1 100644
+--- a/src/RWGltf/RWGltf_CafWriter.cxx
++++ b/src/RWGltf/RWGltf_CafWriter.cxx
+@@ -599,7 +599,29 @@ bool RWGltf_CafWriter::writeJson (const Handle(TDocStd_Document)&  theDocument,
+     {
+       continue;
+     }
+-    aSceneNodeMap.Add (aDocNode);
++
++    bool hasMeshData = false;
++    if (!aDocNode.IsAssembly)
++    {
++      for (RWMesh_FaceIterator aFaceIter (aDocNode.RefLabel, TopLoc_Location(), true, aDocNode.Style); aFaceIter.More(); aFaceIter.Next())
++      {
++        if (!toSkipFaceMesh (aFaceIter))
++        {
++          hasMeshData = true;
++          break;
++        }
++      }
++    }
++    if (hasMeshData)
++    {
++      aSceneNodeMap.Add (aDocNode);
++    }
++    else
++    {
++      // glTF disallows empty meshes / primitive arrays
++      const TCollection_AsciiString aNodeName = readNameAttribute (aDocNode.RefLabel);
++      Message::SendWarning (TCollection_AsciiString("RWGltf_CafWriter skipped node '") + aNodeName + "' without triangulation data");
++    }
+   }
+ 
+   rapidjson::OStreamWrapper aFileStream (aGltfContentFile);
+@@ -1225,20 +1247,8 @@ void RWGltf_CafWriter::writeMeshes (const RWGltf_GltfSceneNodeMap& theSceneNodeM
+   {
+     const XCAFPrs_DocumentNode& aDocNode = aSceneNodeIter.Value();
+     const TCollection_AsciiString aNodeName = readNameAttribute (aDocNode.RefLabel);
+-    {
+-      RWMesh_FaceIterator aFaceIter(aDocNode.RefLabel, TopLoc_Location(), false);
+-      if (!aFaceIter.More())
+-      {
+-        Message::SendWarning (TCollection_AsciiString("RWGltf_CafWriter skipped node '") + aNodeName + "' without triangulation data");
+-        continue;
+-      }
+-    }
+-    myWriter->StartObject();
+-    myWriter->Key ("name");
+-    myWriter->String (aNodeName.ToCString());
+-    myWriter->Key ("primitives");
+-    myWriter->StartArray();
+ 
++    bool toStartPrims = true;
+     Standard_Integer aNbFacesInNode = 0;
+     for (RWMesh_FaceIterator aFaceIter (aDocNode.RefLabel, TopLoc_Location(), true, aDocNode.Style); aFaceIter.More(); aFaceIter.Next(), ++aNbFacesInNode)
+     {
+@@ -1247,6 +1257,16 @@ void RWGltf_CafWriter::writeMeshes (const RWGltf_GltfSceneNodeMap& theSceneNodeM
+         continue;
+       }
+ 
++      if (toStartPrims)
++      {
++        toStartPrims = false;
++        myWriter->StartObject();
++        myWriter->Key ("name");
++        myWriter->String (aNodeName.ToCString());
++        myWriter->Key ("primitives");
++        myWriter->StartArray();
++      }
++
+       const RWGltf_GltfFace& aGltfFace = myBinDataMap.Find (aFaceIter.Face());
+       const TCollection_AsciiString aMatId = theMaterialMap.FindMaterial (aFaceIter.FaceStyle());
+       myWriter->StartObject();
+@@ -1281,8 +1301,12 @@ void RWGltf_CafWriter::writeMeshes (const RWGltf_GltfSceneNodeMap& theSceneNodeM
+       }
+       myWriter->EndObject();
+     }
+-    myWriter->EndArray();
+-    myWriter->EndObject();
++
++    if (!toStartPrims)
++    {
++      myWriter->EndArray();
++      myWriter->EndObject();
++    }
+   }
+   myWriter->EndArray();
+ #else
+@@ -1310,19 +1334,16 @@ void RWGltf_CafWriter::writeNodes (const Handle(TDocStd_Document)&  theDocument,
+        aDocExplorer.More(); aDocExplorer.Next())
+   {
+     const XCAFPrs_DocumentNode& aDocNode = aDocExplorer.Current();
+-    {
+-      RWMesh_FaceIterator aFaceIter(aDocNode.RefLabel, TopLoc_Location(), false);
+-      if (!aFaceIter.More())
+-      {
+-        continue;
+-      }
+-    }
+     if (theLabelFilter != NULL
+     && !theLabelFilter->Contains (aDocNode.Id))
+     {
+       continue;
+     }
+ 
++    // keep empty nodes
++    //RWMesh_FaceIterator aFaceIter (aDocNode.RefLabel, TopLoc_Location(), false);
++    //if (!aFaceIter.More()) { continue; }
++
+     Standard_Integer aNodeIndex = aSceneNodeMapWithChildren.Add (aDocNode);
+     if (aDocExplorer.CurrentDepth() == 0)
+     {
+@@ -1443,11 +1464,11 @@ void RWGltf_CafWriter::writeNodes (const Handle(TDocStd_Document)&  theDocument,
+     }
+     if (!aDocNode.IsAssembly)
+     {
+-      myWriter->Key ("mesh");
+       // Mesh order of current node is equal to order of this node in scene nodes map
+       Standard_Integer aMeshIdx = theSceneNodeMap.FindIndex (aDocNode.Id);
+       if (aMeshIdx > 0)
+       {
++        myWriter->Key ("mesh");
+         myWriter->Int (aMeshIdx - 1);
+       }
+     }
+diff --git a/src/RWGltf/RWGltf_GltfJsonParser.cxx b/src/RWGltf/RWGltf_GltfJsonParser.cxx
+index 9d2add6d21..c2ea361ffb 100644
+--- a/src/RWGltf/RWGltf_GltfJsonParser.cxx
++++ b/src/RWGltf/RWGltf_GltfJsonParser.cxx
+@@ -1317,7 +1317,8 @@ bool RWGltf_GltfJsonParser::gltfParseMesh (TopoDS_Shape& theMeshShape,
+ {
+   const RWGltf_JsonValue* aName  = findObjectMember (theMesh, "name");
+   const RWGltf_JsonValue* aPrims = findObjectMember (theMesh, "primitives");
+-  if (!aPrims->IsArray())
++  if (aPrims == NULL
++  || !aPrims->IsArray())
+   {
+     reportGltfError ("Primitive array attributes within Mesh '" + theMeshId + "' is not an array.");
+     return false;
+diff --git a/tests/de_mesh/gltf_write/empty b/tests/de_mesh/gltf_write/empty
+new file mode 100644
+index 0000000000..e10954505a
+--- /dev/null
++++ b/tests/de_mesh/gltf_write/empty
+@@ -0,0 +1,21 @@
++puts "========"
++puts "0032061: Data Exchange, RWGltf_CafWriter - exporting XBF file produces an invalid glTF document"
++puts "========"
++
++set aTmpGltf "${imagedir}/${casename}_tmp.glb"
++pload MODELING OCAF XDE VISUALIZATION
++
++# create a document with one shape without triangulation
++box b1 0 0 0 1 2 3
++box b2 3 3 3 1 2 3
++compound ce
++compound b1 b2 ce cc
++incmesh b2 1
++XNewDoc   DD
++XAddShape DD cc 1
++WriteGltf DD "$aTmpGltf"
++Close     DD
++
++ReadGltf  D "$aTmpGltf"
++XGetOneShape s D
++checknbshapes s -face 6 -compound 1


### PR DESCRIPTION
issue:0032061,
info: Data Exchange, RWGltf_CafWriter - exporting XBF file produces an invalid glTF document
Empty Nodes are now skipped while filling in Scene node map.