### PR TITLE
Docs: added resolve fallback definitions for react config-overrides.js and double quotes on some of the docker run options

### DIFF
--- a/website/docs/02-getting-started/02-configure-bundler.md
+++ b/website/docs/02-getting-started/02-configure-bundler.md
@@ -76,6 +76,18 @@ Unfortunately, bundlers behave inconsistently when dealing with `.wasm` assets, 
             },
           }
         );
+        
+        config.resolve.fallback =
+        {
+            fs: false,
+            perf_hooks: false,
+            os: false,
+            path: false,
+            worker_threads: false,
+            crypto: false,
+            stream: false
+        }
+        
         return config;
       },
     };

--- a/website/docs/03-app-dev-workflow/03-custom-builds.md
+++ b/website/docs/03-app-dev-workflow/03-custom-builds.md
@@ -79,8 +79,8 @@ Custom builds are defined using YAML files. One YAML file can contain multiple m
       docker run \
         --rm \
         -it \
-        -v $(pwd):/src \
-        -u $(id -u):$(id -g) \
+        -v "$(pwd):/src" \
+        -u "$(id -u):$(id -g)" \
         donalffons/opencascade.js \
         test.yml
       ```

--- a/website/docs/05-advanced/03-multi-threading/02-custom-build.md
+++ b/website/docs/05-advanced/03-multi-threading/02-custom-build.md
@@ -41,8 +41,8 @@ mainBuild:
 
 ```sh
 docker run \
-  -v $(pwd):/src \
-  -u $(id -u):$(id -g) \
+  -v "$(pwd):/src" \
+  -u "$(id -u):$(id -g)" \
   donalffons/opencascade.js:multi-threaded \
   ./opencascade.full.multi-threaded.yml
 ```


### PR DESCRIPTION
I suppose people using react without typescript may not see the error by using config-overrides from the docs example, but I had some trouble when building the code. Maybe not all options are required for TS as it was complaining about 'fs' dependency mostly.

Double quote fix was needed on macOS, but I suppose it should still work on windows. If not, let me know.

P.S  Hope it's ok to go from forked master to master wit this pull request.