### PR TITLE
Make bindings generation dramatically faster

### DIFF
--- a/src/Common.py
+++ b/src/Common.py
@@ -33,3 +33,4 @@ includePathArgs = \
   ])) + \
   list(map(lambda x: "-I" + x, ocIncludePaths + additionalIncludePaths))
   
+ocIncludeStatements = os.linesep.join(map(lambda x: "#include \"" + os.path.basename(x) + "\"", list(sorted(ocIncludeFiles))))

--- a/src/TuInfo.py
+++ b/src/TuInfo.py
@@ -1,0 +1,52 @@
+import clang.cindex
+from Common import includePathArgs, ocIncludeStatements
+from filter.filterTypedefs import filterTypedef
+from filter.filterEnums import filterEnum
+from wasmGenerator.Common import ignoreDuplicateTypedef
+
+def parse(additionalCppCode = ""):
+  index = clang.cindex.Index.create()
+  translationUnit = index.parse(
+    "myMain.h", [
+      "-x",
+      "c++",
+      "-stdlib=libc++",
+      "-D__EMSCRIPTEN__"
+    ] + includePathArgs,
+    [["myMain.h", ocIncludeStatements + "\n" + additionalCppCode]]
+  )
+
+  if len(translationUnit.diagnostics) > 0:
+    print("Diagnostic Messages:")
+    for d in translationUnit.diagnostics:
+      print("  " + d.format())
+
+  return translationUnit
+
+def templateTypedefGenerator(tu):
+  return list(filter(
+    lambda x:
+      x.kind == clang.cindex.CursorKind.TYPEDEF_DECL and
+      not (x.get_definition() is None or not x == x.get_definition()) and
+      filterTypedef(x) and
+      x.type.get_num_template_arguments() != -1 and
+      not ignoreDuplicateTypedef(x),
+    tu.cursor.get_children()))
+
+def typedefGenerator(tu):
+  return list(filter(lambda x: x.kind == clang.cindex.CursorKind.TYPEDEF_DECL, tu.cursor.get_children()))
+
+def allChildrenGenerator(tu):
+  return list(tu.cursor.get_children())
+
+def enumGenerator(tu):
+  return list(filter(lambda x: x.kind == clang.cindex.CursorKind.ENUM_DECL and filterEnum(x), tu.cursor.get_children()))
+
+
+class TuInfo:
+  def __init__(self, customCode):
+    self.tu = parse(customCode)
+    self.allChildren = allChildrenGenerator(self.tu)
+    self.typedefs = typedefGenerator(self.tu)
+    self.enums = enumGenerator(self.tu)
+    self.templateTypedefs = templateTypedefGenerator(self.tu)

--- a/src/TuInfo.py
+++ b/src/TuInfo.py
@@ -1,5 +1,5 @@
 import clang.cindex
-from Common import includePathArgs, ocIncludeStatements
+from Common import includePathArgs, ocIncludeStatements, occtBasePath
 from filter.filterTypedefs import filterTypedef
 from filter.filterEnums import filterEnum
 from wasmGenerator.Common import ignoreDuplicateTypedef
@@ -57,6 +57,16 @@ def classDict(tu):
         d[x.spelling] = x
   return d
 
+def underlyingDict(l, checkOcctBasePath: bool):
+  d = dict()
+  for x in l:
+    if checkOcctBasePath and not x.location.file.name.startswith(occtBasePath):
+      continue
+    if x.underlying_typedef_type.spelling not in d:
+      # Original code didn't handle duplicate names, that seems bad?
+      d[x.underlying_typedef_type.spelling] = x
+  return d
+
 
 class TuInfo:
   def __init__(self, customCode):
@@ -66,3 +76,5 @@ class TuInfo:
     self.enums = enumGenerator(self.tu)
     self.templateTypedefs = templateTypedefGenerator(self.tu)
     self.classDict = classDict(self.tu)
+    self.typedefUnderlyingDict = underlyingDict(self.typedefs, True)
+    self.templateTypedefUnderlyingDict = underlyingDict(self.templateTypedefs, False)

--- a/src/TuInfo.py
+++ b/src/TuInfo.py
@@ -42,6 +42,21 @@ def allChildrenGenerator(tu):
 def enumGenerator(tu):
   return list(filter(lambda x: x.kind == clang.cindex.CursorKind.ENUM_DECL and filterEnum(x), tu.cursor.get_children()))
 
+def classDict(tu):
+  d = dict()
+  for x in tu.cursor.get_children():
+    if (
+      x.kind == clang.cindex.CursorKind.CLASS_DECL or
+      x.kind == clang.cindex.CursorKind.STRUCT_DECL
+    ) and not (
+      x.get_definition() is None or
+      not x == x.get_definition()
+    ):
+      if x.spelling not in d:
+        # Original code didn't handle duplicate names, that seems bad?
+        d[x.spelling] = x
+  return d
+
 
 class TuInfo:
   def __init__(self, customCode):
@@ -50,3 +65,4 @@ class TuInfo:
     self.typedefs = typedefGenerator(self.tu)
     self.enums = enumGenerator(self.tu)
     self.templateTypedefs = templateTypedefGenerator(self.tu)
+    self.classDict = classDict(self.tu)

--- a/src/bindings.py
+++ b/src/bindings.py
@@ -107,7 +107,7 @@ class Bindings:
 
   def processClass(self, theClass, templateDecl = None, templateArgs = None):
     output = ""
-    isAbstract = isAbstractClass(theClass, self.tuInfo.tu)
+    isAbstract = isAbstractClass(theClass, self.tuInfo.classDict)
     if not isAbstract:
       output += self.processSimpleConstructor(theClass)
     for method in theClass.get_children():

--- a/src/generateBindings.py
+++ b/src/generateBindings.py
@@ -196,7 +196,7 @@ def generateCustomCodeBindings(customCode):
 
   embindPreamble = ocIncludeStatements + "\n" + referenceTypeTemplateDefs + "\n" + customCode
 
-  tuInfo = TuInfo("")
+  tuInfo = TuInfo(customCode)
   process(tuInfo, ".cpp", embindGenerationFuncClasses, embindGenerationFuncTemplates, embindGenerationFuncEnums, embindPreamble, True)
   process(tuInfo, ".d.ts.json", typescriptGenerationFuncClasses, typescriptGenerationFuncTemplates, typescriptGenerationFuncEnums, "", True)
 

--- a/src/generateBindings.py
+++ b/src/generateBindings.py
@@ -70,7 +70,7 @@ def filterEnums(child, customBuild):
     child.kind == clang.cindex.CursorKind.ENUM_DECL
   )
 
-def processChildBatch(generator, extension: str, filterFunction: Callable[[any], bool], processFunction: Callable[[any, any], str], typedefGenerator: any, templateTypedefGenerator: any, preamble: str, customCode):
+def processChildren(generator, extension: str, filterFunction: Callable[[any], bool], processFunction: Callable[[any, any], str], typedefGenerator: any, templateTypedefGenerator: any, preamble: str, customCode):
   tu = parse(customCode or "")
   children = list(generator(tu))
 
@@ -98,9 +98,6 @@ def processChildBatch(generator, extension: str, filterFunction: Callable[[any],
 def split(a, n):
   k, m = divmod(len(a), n)
   return (a[i * k + min(i, m):(i + 1) * k + min(i + 1, m)] for i in range(n))
-
-def processChildren(generator, extension: str, filterFunction: Callable[[any], bool], processFunction: Callable[[any, any], str], typedefs: any, templateTypedefs: any, preamble: str, customCode):
-  processChildBatch(generator, extension, filterFunction, processFunction, typedefs, templateTypedefs, preamble, customCode)
 
 def processTemplate(child):
   templateRefs = list(filter(lambda x: x.kind == clang.cindex.CursorKind.TEMPLATE_REF, child.get_children()))

--- a/src/wasmGenerator/Common.py
+++ b/src/wasmGenerator/Common.py
@@ -6,19 +6,9 @@ class SkipException(Exception):
 def getPureVirtualMethods(theClass):
   return list(filter(lambda x: x.is_pure_virtual_method(), list(theClass.get_children())))
 
-def isAbstractClass(theClass, tu):
-  allClasses = list(filter(lambda x:
-    (
-      x.kind == clang.cindex.CursorKind.CLASS_DECL or
-      x.kind == clang.cindex.CursorKind.STRUCT_DECL
-    ) and
-    not (
-      x.get_definition() is None or
-      not x == x.get_definition()
-    ),
-    tu.cursor.get_children()))
+def isAbstractClass(theClass, classDict):
   baseSpec = list(filter(lambda x: x.kind == clang.cindex.CursorKind.CXX_BASE_SPECIFIER and x.access_specifier == clang.cindex.AccessSpecifier.PUBLIC, list(theClass.get_children())))
-  baseClasses = list(map(lambda y: next((x for x in allClasses if x.spelling == y.type.spelling)), baseSpec))
+  baseClasses = [classDict[y.type.spelling] for y in baseSpec if y.type.spelling in classDict]
 
   pureVirtualMethods = getPureVirtualMethods(theClass)
   if len(pureVirtualMethods) > 0:


### PR DESCRIPTION
This series of changes makes generation of the bindings dramatically faster, by fixing a number of issues around re-parsing things, re-doing expensive work, doing O(n) scans when O(1) lookups are possible, etc. It also slightly simplifies some of the code by removing the multiprocessing layer for bindings generation. Despite now being single-threaded, the total time for bindings generation on my 16-core machine drops from 8 minutes to nearly instant. (I am not sure what percent speedup that is, but it's huge!)